### PR TITLE
Devcontainer definition for cc65, z88dk and cmoc compilers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,50 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.154.0/containers/alpine/.devcontainer/base.Dockerfile
+
+# [Choice] Debian version: bookworm, buster, bullseye
+ARG VARIANT="bookworm"
+
+#FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.12-bookworm
+ARG CC65_VERSION="latest"
+
+#RUN apk update && \
+#    apk add --no-cache --virtual .build-deps git build-base
+
+RUN mkdir -p /sdk
+WORKDIR /sdk
+ENV BUILD_SDCC=1
+ENV BUILD_SDCC_HTTP=1
+RUN git clone --recursive https://github.com/z88dk/z88dk.git && \
+    apt update && \
+    apt install -y build-essential bison flex libxml2-dev subversion zlib1g-dev m4 ragel re2c dos2unix texinfo texi2html gdb curl perl cpanminus ccache libboost-all-dev libmodern-perl-perl libyaml-perl liblocal-lib-perl libcapture-tiny-perl libpath-tiny-perl libtext-table-perl libdata-hexdump-perl libregexp-common-perl libclone-perl libfile-slurp-perl pkg-config libgmp3-dev && \
+    cpanm --local-lib=~/perl5 App::Prove CPU::Z80::Assembler Data::Dump Data::HexDump File::Path List::Uniq Modern::Perl Object::Tiny::RW Regexp::Common Test::Harness Text::Diff Text::Table YAML::Tiny && \
+    eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib) && \
+    cd z88dk && chmod 777 build.sh && ./build.sh
+    #&& rm -R /sdk/z88dk
+ENV PATH="$PATH:/sdk/z88dk/bin"
+
+WORKDIR /sdk
+RUN git clone https://github.com/cc65/cc65.git
+WORKDIR /sdk/cc65
+RUN echo 'Using CC65 Version: "${CC65_VERSION}"'
+
+RUN if [ "${CC65_VERSION}" != "latest" ]; then \
+    git checkout tags/${CC65_VERSION} -b "${CC65_VERSION}"; \
+    fi
+RUN nice make -j2
+RUN make install PREFIX=/usr prefix=/usr
+
+WORKDIR /sdk
+
+RUN wget http://www.lwtools.ca/releases/lwtools/lwtools-4.22.tar.gz
+RUN tar -xvf lwtools-4.22.tar.gz
+WORKDIR /sdk/lwtools-4.22
+RUN make && make install
+
+WORKDIR /sdk
+RUN wget http://perso.b2b2c.ca/~sarrazip/dev/cmoc-0.1.85.tar.gz
+RUN tar -xvf cmoc-0.1.85.tar.gz
+WORKDIR /sdk/cmoc-0.1.85
+RUN ./configure && make && make install
+
+WORKDIR /sdk

--- a/.devcontainer/devcontainer.env
+++ b/.devcontainer/devcontainer.env
@@ -1,0 +1,8 @@
+CC65_HOME=/sdk/cc65
+CC65_INC=/sdk/cc65/include
+CA65_INC=/sdk/cc65/asminc
+LD65_CFG=/sdk/cc65/cfg
+LD65_LIB=/sdk/cc65/lib
+LD65_OBJ=/sdk/cc65/obj
+
+ZCCCFG=/sdk/z88dk/lib/config

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,62 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.154.0/containers/alpine
+{
+	"name": "Cross-Lib",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"VARIANT": "bookworm",
+			"CC65_VERSION": "latest"
+		}
+	},
+
+	"features": {
+		"ghcr.io/atarilynx/devcontainers/make_lnx:latest": {},
+		"ghcr.io/atarilynx/devcontainers/sprpck:latest": {},
+		"ghcr.io/devcontainers-contrib/features/perl-asdf:2": {},
+        "ghcr.io/devcontainers/features/java:1": {
+            "version": "8",
+            "installGradle": "false",
+            "installMaven": "false"
+        }
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"terminal.integrated.shell.linux": "/bin/ash"
+			},
+			"extensions": [
+				"ms-vscode.makefile-tools",
+				"ms-vscode.hexeditor"
+			]
+		}
+	},
+
+	"postStartCommand": "",
+
+	// Add the IDs of extensions you want installed when the container is created.
+	// Note that some extensions may not work in Alpine Linux. See https://aka.ms/vscode-remote/linux.
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	"mounts": [ ],
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+	"runArgs": [
+		"--env-file", ".devcontainer/devcontainer.env"
+
+		// Mapping COM ports is not yet supported by Remote Containers
+		//"--device", "/dev/ttyS6:/dev/ttyS6",
+		// "--privileged"
+	],
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
Initial version of devcontainer.
It has several developer tools installed, such as make, gcc, python, java and perl.
The container supports cc65, cmoc and z88dk compilers.

Note: relies on the scripts xl and bin2cas to have correct line endings.